### PR TITLE
Fix spacing datafield iphone

### DIFF
--- a/src/Visitors/dataField.ts
+++ b/src/Visitors/dataField.ts
@@ -81,7 +81,7 @@ export class DataField implements Visitor {
       const children = d3.select(this).selectChildren()
       children.attr('dy', (_, j) => {
         const index = i * children.size() + j
-        return `${(index - offset) * lineHeight}rem`
+        return `${(index - offset) * lineHeight * 16}px`
       })
     })
   }


### PR DESCRIPTION
rem does not work correctly in safari, so use pixels instead. For the most common default browser font size of 16px, 1rem corresponds to 16px