### PR TITLE
Add custom mouseover formatter per chart

### DIFF
--- a/examples/mouseover/index.html
+++ b/examples/mouseover/index.html
@@ -12,6 +12,7 @@
     <div id="chart-container-4" class="chart-container"></div>
     <div id="chart-container-5" class="chart-container"></div>
     <div id="chart-container-6" class="chart-container"></div>
+    <div id="chart-container-7" class="chart-container"></div>
     <script type="module" src="/examples/mouseover/mouseover.ts"></script>
   </body>
 </html>

--- a/examples/mouseover/mouseover.ts
+++ b/examples/mouseover/mouseover.ts
@@ -178,7 +178,7 @@ axesFormatterNoExtent.accept(mouseOverNoExtent)
 function mouseOverFormatter(
   d: void | { point: DataPointXY; style: SvgPropertiesHyphen },
   precision: number,
-): void | HTMLSpanElement {
+): HTMLSpanElement | undefined {
   if (d) {
     const value = d.point
     if (value.y !== undefined) {
@@ -190,6 +190,7 @@ function mouseOverFormatter(
       return spanElement
     }
   }
+  return undefined
 }
 const axesCustomMouseOverLabel = createExampleChart(
   'chart-container-5',

--- a/src/Charts/chart.ts
+++ b/src/Charts/chart.ts
@@ -214,16 +214,9 @@ export abstract class Chart {
   }
 
   mouseOverFormatterCartesian(
-    mouse: [number, number],
+    d: void | { point: DataPointXY; style: SvgPropertiesHyphen },
     precision: number,
-    xScales: Array<any>,
-    yScales: Array<any>,
   ): void | HTMLSpanElement {
-    const xIndex = this.axisIndex.x.axisIndex
-    const xScale = xScales[xIndex]
-    const yIndex = this.axisIndex.y.axisIndex
-    const yScale = yScales[yIndex]
-    const d = this.onPointerMove(xScale.invert(mouse[0]), xScale, yScale)
     if (this.options.mouseover === undefined || this.options.mouseover.formatter === undefined) {
       return this.defaultMouseOverFormatterCartesian(d, precision)
     } else {

--- a/src/Charts/chart.ts
+++ b/src/Charts/chart.ts
@@ -58,7 +58,7 @@ export interface MouseOverOptions {
   formatter?: (
     d: void | { point: DataPointXY; style: SvgPropertiesHyphen },
     precision: number,
-  ) => void | HTMLSpanElement
+  ) => HTMLSpanElement | undefined
   textFormatter?: (d: DataValue, precision: number) => string
 }
 
@@ -216,7 +216,7 @@ export abstract class Chart {
   mouseOverFormatterCartesian(
     d: void | { point: DataPointXY; style: SvgPropertiesHyphen },
     precision: number,
-  ): void | HTMLSpanElement {
+  ): HTMLSpanElement | undefined {
     if (this.options.mouseover === undefined || this.options.mouseover.formatter === undefined) {
       return this.defaultMouseOverFormatterCartesian(d, precision)
     } else {
@@ -227,7 +227,7 @@ export abstract class Chart {
   protected defaultMouseOverFormatterCartesian(
     d: void | { point: DataPointXY; style: SvgPropertiesHyphen },
     precision: number,
-  ): void | HTMLSpanElement {
+  ): HTMLSpanElement | undefined {
     if (d) {
       let color = d.style?.color
       if (color) {
@@ -242,6 +242,7 @@ export abstract class Chart {
         return spanElement
       }
     }
+    return undefined
   }
 
   protected defaultMouseOverTextFormatter(data: DataValue, precision: number): string {

--- a/src/Charts/chart.ts
+++ b/src/Charts/chart.ts
@@ -217,7 +217,7 @@ export abstract class Chart {
     d: void | { point: DataPointXY; style: SvgPropertiesHyphen },
     precision: number,
   ): HTMLSpanElement | undefined {
-    if (this.options.mouseover === undefined || this.options.mouseover.formatter === undefined) {
+    if (this.options.mouseover?.textFormatter === undefined) {
       return this.defaultMouseOverFormatterCartesian(d, precision)
     } else {
       return this.options.mouseover.formatter(d, precision)
@@ -261,10 +261,7 @@ export abstract class Chart {
   }
 
   protected mouseOverTextFormatter(d: DataValue, precision: number): string {
-    if (
-      this.options.mouseover === undefined ||
-      this.options.mouseover.textFormatter === undefined
-    ) {
+    if (this.options.mouseover?.textFormatter === undefined) {
       return this.defaultMouseOverTextFormatter(d, precision)
     } else {
       return this.options.mouseover.textFormatter(d, precision)

--- a/src/Charts/chart.ts
+++ b/src/Charts/chart.ts
@@ -203,6 +203,8 @@ export abstract class Chart {
     }
   }
 
+  mouseOverFormatterCartesian(mouse: [number, number]): void | HTMLSpanElement {}
+
   protected defaultToolTipFormatterCartesian(d): HTMLElement {
     const xKey = this.dataKeys.x
     const yKey = this.dataKeys.y

--- a/src/Visitors/mouseOver.ts
+++ b/src/Visitors/mouseOver.ts
@@ -115,7 +115,7 @@ export class MouseOver implements Visitor {
         const extent = this.axes.chartsExtent('y', chart.axisIndex.y.axisIndex, {})
         const precision = d3.precisionFixed((extent[1] - extent[0]) / 100)
         const pointData = chart.onPointerMove(xScale.invert(mouse[0]), xScale, yScale)
-        const spanElement: void | HTMLSpanElement = chart.mouseOverFormatterCartesian(
+        const spanElement: HTMLSpanElement | undefined = chart.mouseOverFormatterCartesian(
           pointData,
           precision,
         )

--- a/src/Visitors/mouseOver.ts
+++ b/src/Visitors/mouseOver.ts
@@ -108,13 +108,16 @@ export class MouseOver implements Visitor {
     const seen = new Set()
     for (const chart of this.axes.charts) {
       if (traces.includes(chart.id) && chart.visible && !seen.has(chart.id)) {
+        const xIndex = chart.axisIndex.x.axisIndex
+        const xScale = this.axes.xScales[xIndex]
+        const yIndex = chart.axisIndex.y.axisIndex
+        const yScale = this.axes.yScales[yIndex]
         const extent = this.axes.chartsExtent('y', chart.axisIndex.y.axisIndex, {})
         const precision = d3.precisionFixed((extent[1] - extent[0]) / 100)
+        const pointData = chart.onPointerMove(xScale.invert(mouse[0]), xScale, yScale)
         const spanElement: void | HTMLSpanElement = chart.mouseOverFormatterCartesian(
-          mouse,
+          pointData,
           precision,
-          this.axes.xScales,
-          this.axes.yScales,
         )
         if (spanElement) {
           spanElements.push(spanElement)


### PR DESCRIPTION
Use case is to be able to add the unit (of the axis) to the label inside the mouseover.

Idea behind the changes is that the chart knows best what kind of data it has, and what it's style is, like the `toolTipFormatter`. By making the formatter customizable, something like a unit can be added.