### PR TITLE
Add support for matrix with time scale

### DIFF
--- a/examples/matrix/index.html
+++ b/examples/matrix/index.html
@@ -8,6 +8,7 @@
     <theme-button></theme-button>
     <div id="chart-container-sparsity" class="chart-container"></div>
     <div id="chart-container-availability" class="chart-container"></div>
+    <div id="chart-container-time" class="chart-container"></div>
     <script type="module" src="/examples/matrix/matrix.ts"></script>
   </body>
 </html>

--- a/examples/matrix/matrix.css
+++ b/examples/matrix/matrix.css
@@ -14,3 +14,8 @@
   width: 100%;
   height: 100px;
 }
+
+#chart-container-time {
+  width: 100%;
+  height: 200px;
+}

--- a/examples/matrix/matrix.ts
+++ b/examples/matrix/matrix.ts
@@ -7,6 +7,7 @@ import '@shared/theme-button'
 import exampleDataComplete from './example-data.json'
 
 import { AxisType, CartesianAxes, ChartMatrix, TooltipAnchor } from '@lib'
+import { generateExampleTimeSeriesData } from '@shared'
 
 interface ExampleMatrixData {
   i: number
@@ -28,10 +29,10 @@ function generateExampleMatrix(
   return data
 }
 
-function createMatrixAxes(containerId: string): CartesianAxes {
+function createMatrixAxes(containerId: string, xAxisType: AxisType): CartesianAxes {
   const container = document.getElementById(containerId)
   return new CartesianAxes(container, null, null, {
-    x: [{ type: AxisType.band }],
+    x: [{ type: xAxisType }],
     y: [{ type: AxisType.band }],
     margin: {
       top: 0,
@@ -44,7 +45,7 @@ function createMatrixAxes(containerId: string): CartesianAxes {
 }
 
 // Create matrix plot showing the (random) sparsity pattern of a matrix.
-const axesSparse = createMatrixAxes('chart-container-sparsity')
+const axesSparse = createMatrixAxes('chart-container-sparsity', AxisType.band)
 const matrixData = generateExampleMatrix(25, 25, 0.7)
 const matrixSparse = new ChartMatrix(matrixData, {
   x: {
@@ -88,7 +89,7 @@ const colorForAvailability = (availability: string) => {
       return 'black'
   }
 }
-const axesAvailability = createMatrixAxes('chart-container-availability')
+const axesAvailability = createMatrixAxes('chart-container-availability', AxisType.band)
 const matrixAvailability = new ChartMatrix(exampleDataComplete, {
   x: {
     paddingOuter: 0.1,
@@ -119,3 +120,31 @@ matrixAvailability.addTo(
 // Note: we cannot redraw with autoscale enabled, as this cuts off data. See
 //       issue #132.
 axesAvailability.redraw({})
+
+// Generate simple scalar example data.
+const startTime = new Date('2025-01-01T12:00Z')
+const endTime = new Date('2025-01-02T12:00Z')
+const exampleData = generateExampleTimeSeriesData([startTime, endTime], [-2, 4], 100).map(
+  (event) => ({
+    x: event.x,
+    y: Math.round(event.y)
+  }),
+)
+
+const axesTime = createMatrixAxes('chart-container-time', AxisType.time)
+
+const matrixTime = new ChartMatrix(exampleData, {
+  color: { map: () => 'blue' },
+})
+matrixTime.addTo(
+  axesTime,
+  {
+    x: { key: 'x', axisIndex: 0 },
+    y: { key: 'y', axisIndex: 0 },
+  },
+  'example-time',
+  {},
+)
+axesTime.redraw({
+  x: { autoScale: true },
+})

--- a/examples/matrix/matrix.ts
+++ b/examples/matrix/matrix.ts
@@ -124,23 +124,26 @@ axesAvailability.redraw({})
 // Generate simple scalar example data.
 const startTime = new Date('2025-01-01T12:00Z')
 const endTime = new Date('2025-01-02T12:00Z')
-const exampleData = generateExampleTimeSeriesData([startTime, endTime], [-2, 4], 100).map(
-  (event) => ({
+const colors = ['red', 'green', 'blue', 'orange', 'purple', 'cyan']
+const exampleData = generateExampleTimeSeriesData([startTime, endTime], [-2, 4], 10).map(
+  (event, i) => ({
     x: event.x,
-    y: Math.round(event.y)
+    y: Math.round(event.y),
+    color: colors[i % colors.length],
   }),
 )
 
 const axesTime = createMatrixAxes('chart-container-time', AxisType.time)
 
 const matrixTime = new ChartMatrix(exampleData, {
-  color: { map: () => 'blue' },
+  color: { map: (value: string) => value },
 })
 matrixTime.addTo(
   axesTime,
   {
     x: { key: 'x', axisIndex: 0 },
     y: { key: 'y', axisIndex: 0 },
+    color: { key: 'color' },
   },
   'example-time',
   {},

--- a/src/Axes/cartesianAxes.ts
+++ b/src/Axes/cartesianAxes.ts
@@ -164,14 +164,14 @@ export class CartesianAxes extends Axes {
       const scale = scales[axisIndex]
       if (!scale) continue
 
+      const axisOptions = this.options[axisKey][axisIndex]
       const setCurrentDomain = (domain: [number, number] | [Date, Date]) =>
         this.setDomain(axisKey, axisIndex, domain)
       const makeDomainNice = () => {
-        const updatedDomain = niceDomain(scale.domain(), 16)
+        const updatedDomain = niceDomain(scale.domain(), 16, axisOptions.type)
         setCurrentDomain(updatedDomain)
       }
 
-      const axisOptions = this.options[axisKey][axisIndex]
       const axisScaleOptions: ScaleOptions = {
         domain: axisOptions.domain,
         nice: axisOptions.nice,
@@ -182,6 +182,10 @@ export class CartesianAxes extends Axes {
       if (zoomOptions?.domain) {
         setCurrentDomain(zoomOptions.domain)
         if (zoomOptions?.nice === true) makeDomainNice()
+      } else if (axisOptions.type === AxisType.band) {
+        const charts = this.charts.filter(chart => chart.axisIndex[axisKey]?.axisIndex === axisIndex)
+        const extent = charts.flatMap((chart) => chart.data.map((d) => d[chart.dataKeys[axisKey]]))
+        setCurrentDomain(extent as [number, number] | [Date, Date])
       } else if (zoomOptions.autoScale === true || zoomOptions.fullExtent === true) {
         let defaultExtent
         let dataExtent = new Array(2)
@@ -204,15 +208,6 @@ export class CartesianAxes extends Axes {
         }
         setCurrentDomain(dataExtent as [number, number] | [Date, Date])
         if (zoomOptions?.nice === true) makeDomainNice()
-      } else if (this.options[axisKey][axisIndex].type === AxisType.band) {
-        let extent = new Array(0)
-        for (const chart of this.charts) {
-          if (chart.axisIndex[axisKey]?.axisIndex === axisIndex) {
-            extent = chart.data.map((d) => d[chart.dataKeys[axisKey]])
-            break
-          }
-        }
-        setCurrentDomain(extent as [number, number] | [Date, Date])
       }
       const domain = scale.domain()
       if (initialExtents[axisIndex] === undefined && !isNaN(domain[0]) && !isNaN(domain[1]))

--- a/src/Axes/niceDomain.ts
+++ b/src/Axes/niceDomain.ts
@@ -8,6 +8,7 @@ export function niceDomain(
   count: number,
   axisType = AxisType.value,
 ): [number, number] {
+  if (axisType === AxisType.band) return domain
   if (domain === undefined) return
   // Minimal increment to avoid round extreme values to be on the edge of the chart
   let max = domain[1]

--- a/src/Charts/chartMatrix.ts
+++ b/src/Charts/chartMatrix.ts
@@ -29,9 +29,7 @@ export class ChartMatrix extends Chart {
       return i === 0 ? 0 : xScale(mappedData[i - 1][xKey])
     }
     const getWidthRect = (_: unknown, i: number) => {
-      return i === 0
-        ? xScale(mappedData[i][xKey])
-        : xScale(mappedData[i][xKey]) - xScale(mappedData[i - 1][xKey])
+      return i === 0 ? 0 : xScale(mappedData[i][xKey]) - xScale(mappedData[i - 1][xKey])
     }
 
     const colorScale = d3.scaleLinear().domain([0, 1])


### PR DESCRIPTION
For now created an issue for bar and matrix chart's first item being hidden: https://github.com/Deltares/fews-web-oc-charts/issues/164. OC uses the timestep.