### PR TITLE
Always disable panning when the window loses focus

### DIFF
--- a/src/Visitors/panHandler.ts
+++ b/src/Visitors/panHandler.ts
@@ -194,6 +194,10 @@ export class PanHandler implements Visitor {
     if (!isModifierKeyPress(keyboardEvent, this.modifierKey)) return
     window.addEventListener('keyup', this.keyUpCallback)
     window.removeEventListener('keydown', this.keyDownCallback)
+    // Also check whether the window loses focus, since Windows might highjack
+    // the keyup event, so we stay in a panning state. Just disable panning if
+    // we lose focus.
+    window.addEventListener('blur', () => this.disablePanning(), { once: true })
     this.enablePanning()
   }
 


### PR DESCRIPTION
Sometimes Windows highjacks our keyup events, for example when the Sticky Keys keyboard shortcut is triggered. To prevent us from staying in a panning state indefinitely when this happens, just disable panning when the window loses focus.