### PR TITLE
chore: update devDependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/luxon": "^3.7.1",
         "@types/node": "^22.13.4",
         "@vitest/browser": "^4.0.8",
+        "@vitest/browser-playwright": "^4.0.8",
         "csstype": "^3.1.3",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
@@ -2063,6 +2064,30 @@
       },
       "peerDependencies": {
         "vitest": "4.0.8"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.0.8.tgz",
+      "integrity": "sha512-MUi0msIAPXcA2YAuVMcssrSYP/yylxLt347xyTC6+ODl0c4XQFs0d2AN3Pc3iTa0pxIGmogflUV6eogXpPbJeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.0.8",
+        "@vitest/mocker": "4.0.8",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.0.8"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/luxon": "^3.7.1",
     "@types/node": "^22.13.4",
     "@vitest/browser": "^4.0.8",
+    "@vitest/browser-playwright": "^4.0.8",
     "csstype": "^3.1.3",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
@@ -79,7 +80,7 @@
   "bugs": {
     "url": "https://github.com/Deltares/fews-web-oc-charts/issues"
   },
-    "publishConfig": {
+  "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { type ViteUserConfig, defineConfig } from 'vitest/config'
+import { playwright } from '@vitest/browser-playwright'
 
 type TestConfig = NonNullable<ViteUserConfig['test']>
 type BrowserConfig = NonNullable<TestConfig['browser']>
@@ -11,7 +12,8 @@ function getBrowserInstances(mode: string): BrowserInstanceConfig[] {
   // Run test suite with all browsers in Playwright when running in "all-browsers"
   // mode, otherwise, only run in chromium.
   // FIXME: for now, run with only chromium as other browsers are flaky.
-  const browsers = mode === 'all-browsers' ? ['chromium'] : ['chromium']
+  const browsers: ('chromium' | 'firefox' | 'webkit')[] =
+    mode === 'all-browsers' ? ['chromium'] : ['chromium']
   return browsers.map((browser) => ({ browser }))
 }
 
@@ -21,7 +23,7 @@ export default defineConfig((configEnv) => {
       browser: {
         enabled: true,
         screenshotFailures: false,
-        provider: 'playwright',
+        provider: playwright(),
         headless: true,
         api: 5174,
         instances: getBrowserInstances(configEnv.mode),


### PR DESCRIPTION
- Upgraded @eslint/js from ^9.36.0 to ^9.39.1
- Upgraded @rollup/plugin-typescript from ^12.1.4 to ^12.3.0
- Upgraded @vitest/browser from ^3.2.4 to ^4.0.8
- Upgraded eslint from ^9.36.0 to ^9.39.1
- Upgraded playwright from ^1.55.0 to ^1.56.1
- Upgraded sass-embedded from ^1.93.0 to ^1.93.3
- Upgraded sonarqube-scanner from ^3.5.0 to ^4.3.2
- Upgraded typescript from ^5.9.2 to ^5.9.3
- Upgraded typescript-eslint from ^8.44.1 to ^8.46.4
- Upgraded vite from ^7.1.7 to ^7.2.2
- Upgraded vitest from ^3.2.4 to ^4.0.8